### PR TITLE
Reset _playbackTimerId to null

### DIFF
--- a/src/VideoMock.ts
+++ b/src/VideoMock.ts
@@ -386,6 +386,7 @@ namespace videomock {
   VideoMock.prototype._stopPlaybackTimer = function(): void {
     if (this._playbackTimerId) {
       clearInterval(this._playbackTimerId)
+      this._playbackTimerId = null
     }
   }
 


### PR DESCRIPTION
Small bugfix to make sure the playback is possible again after pausing the videomock.
