### PR TITLE
Basic support for time ranges of video.played

### DIFF
--- a/src/ui/VideoMockUI.ts
+++ b/src/ui/VideoMockUI.ts
@@ -112,12 +112,16 @@ namespace videomock.ui {
     }
 
     public updateTimeRanges(): void {
-      if (!this.video.played.length) {
-        this.video.played.addRange(0, this.video.currentTime)
+      // currently using a very basic stub for video.played time ranges
+      // but when you jump around in the video it is not correct yet
+      const played = <videomock.dom.TimeRanges> this.video.played
+
+      if (!played.length) {
+        played.addRange(0, this.video.currentTime)
       } else {
-        this.video.played.ranges[0].start = 0
-        this.video.played.ranges[0].end = this.video.currentTime
-      }
+        played.ranges[0].start = 0
+        played.ranges[0].end = this.video.currentTime
+      }))
     }
 
     private getVideoWidth(): number {

--- a/src/ui/VideoMockUI.ts
+++ b/src/ui/VideoMockUI.ts
@@ -20,7 +20,10 @@ namespace videomock.ui {
         this.percentLoaded = video.buffered.end(video.buffered.length - 1) / video.duration
         this.updateDisplay()
       })
-      video.addEventListener(event.MediaEvent.timeupdate, () => this.updateDisplay())
+      video.addEventListener(event.MediaEvent.timeupdate, () => {
+        this.updateDisplay()
+        this.updateTimeRanges()
+      })
       video.addEventListener(event.MediaEvent.loadstart, () => this.updateDisplay())
       video.addEventListener(event.MediaEvent.progress, () => this.updateDisplay())
       video.addEventListener(event.MediaEvent.ended, () => this.onEnded())
@@ -106,6 +109,15 @@ namespace videomock.ui {
         '<br/>Status: ' + this.status
 
       this.contentContainer.innerHTML = content
+    }
+
+    public updateTimeRanges(): void {
+      if (!this.video.played.length) {
+        this.video.played.addRange(0, this.video.currentTime)
+      } else {
+        this.video.played.ranges[0].start = 0
+        this.video.played.ranges[0].end = this.video.currentTime
+      }
     }
 
     private getVideoWidth(): number {

--- a/src/ui/VideoMockUI.ts
+++ b/src/ui/VideoMockUI.ts
@@ -121,7 +121,7 @@ namespace videomock.ui {
       } else {
         played.ranges[0].start = 0
         played.ranges[0].end = this.video.currentTime
-      }))
+      }
     }
 
     private getVideoWidth(): number {


### PR DESCRIPTION
Time ranges for the `played`, `buffered` and `seekable` properties are initialised but never updated while playing a video. I've added some basic code to update the time ranges of `video.played` on a `timeupdate` event. 

It's definitely not complete, but it's better than nothing!
